### PR TITLE
Fixed misspelling

### DIFF
--- a/lessons-resources/index.html
+++ b/lessons-resources/index.html
@@ -9,7 +9,7 @@ title: Resources
 <h1>Maptime Materials</h1>
 <p>Maptime materials are designed for students to learn with and teachers to teach with. These materials are our open source offering, available for you to fork on Github and modify for your class or notes. All we ask is that you credit Maptime for anything other than personal (just you by yourself) use.</p>
 <p>For all Maptime tutorials, including works in progress, please visit:</p>
-<h2 style="text-align: center;"><a href="http://github.com/maptime" target="_blank">gihub.com/maptime</a></h2>
+<h2 style="text-align: center;"><a href="http://github.com/maptime" target="_blank">github.com/maptime</a></h2>
 <h2><a href="http://github.com/maptime" target="_blank"><img src="jeremy-nyan-cat-trans-001-300x147.png" width="175" height="86"/></a></h2>
 <p>&nbsp;</p>
 <h1>Additional Resources</h1>


### PR DESCRIPTION
In the lessons and resources page, the word Github was Gihub.
