### PR TITLE
A couple little fixes for MaptimeMSP

### DIFF
--- a/_data/chapters.json
+++ b/_data/chapters.json
@@ -972,16 +972,15 @@
         "organizers": [
           {
             "name": "M. Taylor Long",
-            "twitter": "@mtaylorlong"
+            "twitter": "mtaylorlong"
           },
           {
             "name": "Liz Puhl",
-            "twitter": "@LizPuhl"
+            "twitter": "LizPuhl"
           }
         ],
-        "meetup": "http://www.meetup.com/Maptime-MSP",
-        "github": "https://github.com/MaptimeMSP",
-        "comingSoon": true
+        "meetup": "http://www.meetup.com/MaptimeMSP",
+        "github": "https://github.com/MaptimeMSP"
       },
       "geometry": {
         "type": "Point",


### PR DESCRIPTION
Removed "coming soon" (just had our first meetup — we're totally a thing now). Also fixed the @@ issue with our twitter handles on the maptime.io chapters page. Finally, updated our meetup link because we changed it (removed the dash between "Maptime" and "MSP").
