### PR TITLE
"Maptime Miami" -> "MaptimeMiami"

### DIFF
--- a/_data/chapters.json
+++ b/_data/chapters.json
@@ -458,7 +458,7 @@
       "type": "Feature",
       "properties": {
         "location": "Miami, FL",
-        "title": "Maptime Miami",
+        "title": "MaptimeMiami",
         "twitter": "MaptimeMIA",
         "organizers": [
           {


### PR DESCRIPTION
Adding the space made Miami not alphabetical. Oops!
