### PR TITLE
Added mapillary as community tut

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -245,3 +245,9 @@
   tags: 
     - CartoCSS
   link: https://github.com/mapbox/mapbox-studio-mapbox-outdoors.tm2
+
+- name: Mapillary
+  tags: 
+    - Community
+  description: Submit your photos to Mapillary (the "Street View" of OSM)
+  link: https://www.mapillary.com/how.html


### PR DESCRIPTION
Added [mapillary](http://www.mapillary.com/how.html) to the community section of the tutorials page.

Mapillary is roughly the OSM equivalent to Google Street View, and was recently integrated with the iD editor.
