### PR TITLE
add strip_newlines filter for data in chapters.js

### DIFF
--- a/js/chapters.js
+++ b/js/chapters.js
@@ -8,7 +8,7 @@ $(function() {
   var source   = $("#chapters-template").html(),
       $output = $("#chapters-output");
       template = Handlebars.compile(source),
-      data = {{ site.data.chapters | jsonify }},
+      data = {{ site.data.chapters | strip_newlines | jsonify }},
       html = '';
 
   L.mapbox.accessToken = 'pk.eyJ1IjoiZ3JhZmEiLCJhIjoiU2U2QnIzUSJ9.4LnG05Ptvi1sUQ8t68rfgw';


### PR DESCRIPTION
Aiming to fix #115 - it seems any jekyll version `>=2.5` throws a "stack level too deep" error when using the `jsonify` filter in [line 11 of chapters.js](https://github.com/maptime/maptime.github.io/blob/master/js/chapters.js#L11). Adding the filter `strip_newlines` fixes the issue for me, and hoping doesn't create any new issues for lesser versions of jekyll! Would love someone to test this out if they're `<2.5`.  
