### PR TITLE
Fixes overflow on chapter marker popup  #98

### DIFF
--- a/js/chapters.js
+++ b/js/chapters.js
@@ -32,9 +32,10 @@ $(function() {
 
     var chapterMarkers = L.geoJson( data, {
       onEachFeature: function (feature, layer) {
+	    var popupOptions = {'maxWidth' : '1000'};  
         var popupContent = '<h2>'+ feature.properties.title +'</h2>' + 'Twitter: ' + 
           '<a href="http://twitter.com/' + feature.properties.twitter + '" target="_blank">@' + feature.properties.twitter +'</a>';
-        layer.bindPopup(popupContent);
+        layer.bindPopup(popupContent,popupOptions);
         layer.setIcon(new L.Icon({
           iconUrl:'/img/maptime-marker.png',
           iconSize: [24,24],


### PR DESCRIPTION
In Leaflet, the [maxWidth](http://leafletjs.com/reference.html#popup-maxwidth) option of L.popup is 300 by default.

I fixed this issue in my fork by modifying chapters.js.  I just passed a larger maxWidth option to the bindPopup() method of the chapterMarkers variable like so:

```javascript
   var chapterMarkers = L.geoJson( data, {
      onEachFeature: function (feature, layer) {
	    var popupOptions = {'maxWidth' : '1000'};  
        var popupContent = '<h2>'+ feature.properties.title +'</h2>' + 'Twitter: ' + 
          '<a href="http://twitter.com/' + feature.properties.twitter + '" target="_blank">@' + feature.properties.twitter +'</a>';
        layer.bindPopup(popupContent,popupOptions);
        layer.setIcon(new L.Icon({
          iconUrl:'/img/maptime-marker.png',
          iconSize: [24,24],
          iconAnchor: [6,12],
          popupAnchor: [5,-10]
        }));
      }
    });
```
![nooverflow](https://cloud.githubusercontent.com/assets/1992577/5893183/423ccb6e-a4a8-11e4-8415-f21293ecf6f1.png)