### PR TITLE
Responsive menu & meta class

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset='UTF-8'/>
+  <meta name="viewport" content="width=device-width">
   <meta name='twitter:site' content='@{{ site.maptime.twitter }}' />
   <meta property='og:site_name' content='{{ site.maptime.chapter }}' />
   <meta name='twitter:url' content='{{ page.permalink }}' />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,7 @@
     <meta property='og:type' content='website' />
   {% endif %}
   <title>{% if page.url == '/' %}{{site.maptime.chapter}}{% else %}{{site.maptime.chapter}} | {{page.title}}{% endif %}</title>
+  <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
   <link href='http://fonts.googleapis.com/css?family=Comfortaa:400,300,700' rel='stylesheet' type='text/css'>
   <link rel='stylesheet' href='{{site.baseurl}}/css/site.css' type='text/css'/>
   {% for stylesheet in page.css %}

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,6 +1,36 @@
-<nav id="navbar" class=''>
-	<li><a href='{{site.baseurl}}/' class='col2'>Home</a></li>
-	{% for weight in (1..10) %}{% for p in site.pages %}{% if p.weight == weight %}
-  <li{% if p.url == page.url %} class="active"{% endif %}><a href="{{ p.url }}">{{ p.title }}</a></li>
-  {% endif %}{% endfor %}{% endfor %}
-</nav>
+<div class="navbar">
+  <nav id="nav">
+    <ul id="menu-main" class="menu">
+      <li><a href='{{site.baseurl}}/'>Home</a></li>
+      {% for weight in (1..10) %}{% for p in site.pages %}{% if p.weight == weight %}
+      <li{% if p.url == page.url %} class="active"{% endif %}><a href="{{ p.url }}">{{ p.title }}</a></li>
+      {% endif %}{% endfor %}{% endfor %}
+    </ul>
+  </nav>
+  <button class="nav-expand"><img src="/img/menu-hamburger.svg"></button>
+</div>
+
+<script>
+var nav = $('#nav');
+var menu = $('#nav .menu');
+var navButton = $('.nav-expand');
+$('button.nav-expand').on('click', function(){
+  menu.slideToggle(200);
+  navButton.toggleClass('open');
+});
+var blocked = false,
+    threshold = 687;
+$(window).resize(function(){
+  menuCheck($(window).outerWidth(true), blocked, threshold);
+});
+function menuCheck(w, b, t) {
+  if (w>t && !b) {
+    menu.show();
+    blocked = !b;
+    $('.nav-expand').removeClass('open');
+  } else if (w<=t && b) {
+    menu.hide();
+    blocked = !b;
+  }
+}
+</script>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -19,7 +19,7 @@ $('button.nav-expand').on('click', function(){
   navButton.toggleClass('open');
 });
 var blocked = false,
-    threshold = 687;
+    threshold = 800;
 $(window).resize(function(){
   menuCheck($(window).outerWidth(true), blocked, threshold);
 });

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -3,7 +3,7 @@
     <ul id="menu-main" class="menu">
       <li><a href='{{site.baseurl}}/'>Home</a></li>
       {% for weight in (1..10) %}{% for p in site.pages %}{% if p.weight == weight %}
-      <li{% if p.url == page.url %} class="active"{% endif %}><a href="{{ p.url }}">{{ p.title }}</a></li>
+      <li class="{% if p.url == page.url %}active{% endif %} {{ p.menu_class }}"><a href="{{ p.url }}">{{ p.title }}</a></li>
       {% endif %}{% endfor %}{% endfor %}
     </ul>
   </nav>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,8 +1,6 @@
-<div class='tabs col7'>
-	<a href='{{site.baseurl}}/' class='col2'>Home</a>
-	<a href='{{site.baseurl}}/chapters/' class='col2'>Chapters</a>
-	<a href='{{site.baseurl}}/lessons-resources/' class='col2'>Resources</a>
-	<a href='{{site.baseurl}}/about/' class='col2'>About</a>
-	<a href='{{site.baseurl}}/contact/' class='col2'>Contact</a>
-	<a href='{{site.baseurl}}/maptime-summit-2015/' class='col2'><strong>MAPTIME<br/>SUMMIT!</strong></a>
-</div>
+<nav id="navbar" class=''>
+	<li><a href='{{site.baseurl}}/' class='col2'>Home</a></li>
+	{% for weight in (1..10) %}{% for p in site.pages %}{% if p.weight == weight %}
+  <li{% if p.url == page.url %} class="active"{% endif %}><a href="{{ p.url }}">{{ p.title }}</a></li>
+  {% endif %}{% endfor %}{% endfor %}
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,7 @@
 {% include head.html %}
 
 <body>
+  {% include menu.html %}
   {% if page.title == 'About' %}
     <div class='main about col12 contain dark'>
   {% else %} 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,6 @@
     <div class='main col12 contain dark'>
   {% endif %}
     <a href='{{site.baseurl}}/' class='sprite maptime pin-left'>Maptime</a>
-    {% include menu.html %}
     {% include header.html %}
 
   </div>

--- a/about/index.html
+++ b/about/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+weight: 3
 title: About
 description: "This open learning environment for all levels and degrees of knowledge offers intentional support for the beginner. Maptime is simultaneously flexible and structured, creating space for workshops, ongoing projects with a shared goal, and independent/collaborative work time. Beginners most welcome!"
 published: true

--- a/chapters/index.html
+++ b/chapters/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+weight: 1
 title: Chapters
 description: "Once Maptime got started in San Francisco, it wasn't long before cites all over the world started to get involved. Here are all of the Maptime chapters that exist so far, along with the team that puts them together."
 

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+weight: 4
 title: Contact
 description: "There are many folks involved in Maptime activities around the world and a dedicated crew of inidividuals who are making sure everyone has the resources to keep Maptime going. Feel free to reach out and contact us!"
 ---

--- a/css/site.css
+++ b/css/site.css
@@ -75,6 +75,93 @@ h6 a:hover { text-decoration:none;}
   top: 40px;
 }
 
+/* * * * * * * * * * * * * * *
+
+  MAIN NAVIGATION
+
+* * * * * * * * * * * * * * */
+.navbar {
+  background-color:#333;
+  z-index: 100;
+}
+#nav {
+  display:block;
+}
+#nav ul {
+  display:none;
+}
+#nav li {
+  text-align:right;
+  width:100%;
+  padding:7px 10px;
+}
+#nav li a {
+  color:#ffffff;
+  font-size:.9em;
+  font-weight:500;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  padding:.1em .2em;
+}
+#nav li.current_page_item a {
+  background-color:#222;
+}
+#nav-logo {
+  margin: .9em 1em;
+  float:left;
+}
+button.nav-expand {
+  position:relative;
+  z-index: 10;
+  margin:10px 15px 0 0;
+  width:50px;
+  height:50px;
+  border:none;
+  background-color:transparent;
+  float:right;
+}
+button.nav-expand:hover {
+  opacity:.8;
+  cursor:pointer;
+}
+button.nav-expand:focus {
+  outline:none;
+}
+
+@media screen and (min-width: 800px) {
+  .navbar {
+    background:transparent;
+    text-align:right;
+    position:fixed;
+    top:0;
+    width:100%;
+  }
+  #nav ul {
+    float:right;
+    display:block;
+  }
+  #nav li {
+    background-color:transparent;
+    width:auto;
+    padding:0;
+    display:inline-block;
+    padding:10px;
+  }
+  #nav li a:hover {
+    text-decoration: none;
+  }
+  #nav li.current_page_item a {
+    background-color:transparent;
+    border-top:2px solid #ffffff;
+  }
+  #nav-logo {
+    margin:.5em 1em;
+  }
+  button.nav-expand {
+    display:none;
+  }
+}
+
 /* Tab style for links that toggle between views */
 .tabs {
   position: absolute;

--- a/css/site.css
+++ b/css/site.css
@@ -36,9 +36,13 @@ h6 a:hover { text-decoration:none;}
 .about {
   background-image: url('/img/maptime-about.jpg');
 }
-.main h1 {
-  font-size: 80px;
-  line-height: 80px;
+
+.main h1 {}
+@media screen and (min-width: 800px) {
+  .main h1 {
+    font-size: 80px;
+    line-height: 80px;
+  }
 }
 
 .button {
@@ -75,66 +79,53 @@ h6 a:hover { text-decoration:none;}
   top: 40px;
 }
 
-/* * * * * * * * * * * * * * *
-
-  MAIN NAVIGATION
-
-* * * * * * * * * * * * * * */
+/*
+ * MAIN NAVIGATION
+ */
 .navbar {
-  background-color:#333;
+  background:rgb(19,78,102);
   z-index: 100;
 }
-#nav {
-  display:block;
-}
-#nav ul {
-  display:none;
-}
-#nav li {
-  text-align:right;
-  width:100%;
-  padding:7px 10px;
-}
-#nav li a {
-  color:#ffffff;
-  font-size:.9em;
-  font-weight:500;
-  text-transform:uppercase;
-  letter-spacing:.08em;
-  padding:.1em .2em;
-}
-#nav li.current_page_item a {
-  background-color:#222;
-}
-#nav-logo {
-  margin: .9em 1em;
-  float:left;
-}
+#nav { display:block; }
+  #nav ul { display:none; }
+  #nav li {
+    text-align:right;
+    width:100%;
+    padding:7px 10px;
+    border-bottom:1px solid rgba(255,255,255,0.25);
+  }
+  #nav li a {
+    color:#ffffff;
+    font-size:1.1em;
+    font-family:'Comfortaa', cursive;
+    font-weight: bold;
+    text-align:center;
+    display:inline-block;
+    padding:10px 15px;
+    color: rgba(255,255,255,0.8);
+  }
+  #nav li.current_page_item a { background-color:#222; }
+
 button.nav-expand {
   position:relative;
   z-index: 10;
-  margin:10px 15px 0 0;
-  width:50px;
-  height:50px;
+  padding:13px 10px;
   border:none;
-  background-color:transparent;
+  background:rgb(19,78,102);
   float:right;
 }
 button.nav-expand:hover {
   opacity:.8;
   cursor:pointer;
 }
-button.nav-expand:focus {
-  outline:none;
-}
+button.nav-expand:focus { outline:none; }
 
 @media screen and (min-width: 800px) {
   .navbar {
     background:transparent;
     text-align:right;
-    position:fixed;
-    top:0;
-    width:100%;
+    position:absolute;
+    right:0;
   }
   #nav ul {
     float:right;
@@ -144,18 +135,18 @@ button.nav-expand:focus {
     background-color:transparent;
     width:auto;
     padding:0;
-    display:inline-block;
-    padding:10px;
+    float:left;
+    border:none;
   }
+  #nav li a {
+    border-bottom:2px solid rgba(255,255,255,0.25);
+    background:rgba(19,78,102,.6);
+    border-left:1px solid rgba(255,255,255,0.25);
+  }
+  #nav li.active a { background:rgba(19,78,102,.8); }
   #nav li a:hover {
     text-decoration: none;
-  }
-  #nav li.current_page_item a {
-    background-color:transparent;
-    border-top:2px solid #ffffff;
-  }
-  #nav-logo {
-    margin:.5em 1em;
+    background:rgba(19,78,102,.8);
   }
   button.nav-expand {
     display:none;

--- a/css/site.css
+++ b/css/site.css
@@ -144,6 +144,7 @@ button.nav-expand:focus { outline:none; }
     border-left:1px solid rgba(255,255,255,0.25);
   }
   #nav li.active a { background:rgba(19,78,102,.8); }
+  #nav li.event a { background:rgba(31, 166, 70,.8); }
   #nav li a:hover {
     text-decoration: none;
     background:rgba(19,78,102,.8);

--- a/img/menu-hamburger.svg
+++ b/img/menu-hamburger.svg
@@ -1,0 +1,10 @@
+<svg version="1.1" id="menu-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     width="40px" height="25px" viewBox="0 0 18 12" enable-background="new 0 0 18 12" xml:space="preserve">
+<path fill="none" d="z"/>
+<g id="Layer_x25_201">
+    <rect width="40" height="2" fill="#fff"/>
+    <rect y="5" width="18" height="2" fill="#fff"/>
+    <rect y="10" width="18" height="2" fill="#fff"/>
+</g>
+<path fill="none" d="z"/>
+</svg>

--- a/img/menu-hamburger.svg
+++ b/img/menu-hamburger.svg
@@ -1,10 +1,10 @@
 <svg version="1.1" id="menu-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     width="40px" height="25px" viewBox="0 0 18 12" enable-background="new 0 0 18 12" xml:space="preserve">
+     width="40px" height="25px" viewBox="0 0 15 12" enable-background="new 0 0 15 12" xml:space="preserve">
 <path fill="none" d="z"/>
 <g id="Layer_x25_201">
-    <rect width="40" height="2" fill="#fff"/>
-    <rect y="5" width="18" height="2" fill="#fff"/>
-    <rect y="10" width="18" height="2" fill="#fff"/>
+    <rect width="15" height="2" fill="#fff"/>
+    <rect y="5" width="15" height="2" fill="#fff"/>
+    <rect y="10" width="15" height="2" fill="#fff"/>
 </g>
 <path fill="none" d="z"/>
 </svg>

--- a/lessons-resources/index.html
+++ b/lessons-resources/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+weight: 3
 title: Resources
 description: "Getting started? Dive in here. Looking for tutorials? We got 'em. Look here for a list of guides to getting started in all things geo."
 ---

--- a/maptime-summit-2015/index.html
+++ b/maptime-summit-2015/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 weight: 5
+menu_class: event
 title: Maptime Summit!
 description: "June 8, 2015 // UN Headquarters // New York, NY"
 ---

--- a/maptime-summit-2015/index.html
+++ b/maptime-summit-2015/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+weight: 5
 title: Maptime Summit!
 description: "June 8, 2015 // UN Headquarters // New York, NY"
 ---


### PR DESCRIPTION
Hello! I did a bit of re-working on the main navigation menu in response to @bethschechter's issue #161 

## What changed

**Responsive design** that has a "hamburger" (cc @rhewitt22) and is related to #30, which required updates to `/css/site.css` and adding jQuery to the `<head>` as well as a `<script>` to the `_includes/menu.html` file since there isn't a site-wide javascript file. *the gif below is super huge and flickers with my vampire background, sorry!* :fearful: 

![maptime-nav-update](https://cloud.githubusercontent.com/assets/1943001/6819452/4ee8ad0c-d27e-11e4-914d-f234c43411b6.gif)

**Site page looping** with the jekyll `weight` YAML syntax. This allows us to specify a page's `weight` in the YAML if we'd like it to show up in the main navigation. For example, the `/about` page has YAML as follows:

```YAML
---
layout: default
weight: 3
title: About
description: "..."
published: true
---
```

This way we re-order the pages by updating their YAML instead of the `_includes/menu.html` file.

**Custom classes** can be added to the menu items in case we need to style them, a la #161, by adding extra to the YAML as follows:

```YAML
---
layout: default
weight: 5
menu_class: event
title: Maptime Summit!
description: "June 8, 2015 // UN Headquarters // New York, NY"
---
```

This produces the menu item `<li class="event"><a href="...">Maptime Summit!</a></li>` that can be styled with the class `#nav li.event a { /* your styles */ }`

---

This is a pretty large pull request. Apologies if it's too much in one-fell-swoop!