### PR TITLE
Added excerpt separator

### DIFF
--- a/_posts/2015-04-27-help-HOT.md
+++ b/_posts/2015-04-27-help-HOT.md
@@ -13,7 +13,7 @@ by Beth
 As many of you likely already know, a few days ago Nepal was hit with a magnitude 7.8 earthquake. The natural disaster has shattered temples and homes, and left thousands dead or injured. 
 
 What can you do to help? In addition to donating to your favorite relief effort, you can help [Humanitarian Openstreetmap Team (HOT)](http://hot.openstreetmap.org/) to remap the area. 
-
+<!--more-->
 #This week, I'm calling on all Maptimes to put aside your tutorials, and to instead get together to contribute to this cause. 
 
 Props to chapters like Boulder, Alpes and DC for contributing already!


### PR DESCRIPTION
HOT post for the earthquake shows doesn't have an excerpt so it shows the entire post on the front page.  Added the excerpt separator assuming this wasn't intentional.