### PR TITLE
added styles for marker cluster

### DIFF
--- a/css/chapters.css
+++ b/css/chapters.css
@@ -19,3 +19,21 @@
   color:#fff; 
   font-weight: bold;
 }
+
+.marker-cluster-medium {
+  background-color: rgba(127, 47, 85, 0.6);
+}
+.marker-cluster-medium div {
+  background-color: rgba(127, 47, 85, 0.6);
+  color:#fff; 
+  font-weight: bold;
+}
+
+.marker-cluster-large {
+  background-color: rgba(84, 31, 56, 0.6);
+}
+.marker-cluster-large div {
+  background-color: rgba(84, 31, 56, 0.6);
+  color:#fff; 
+  font-weight: bold;
+}


### PR DESCRIPTION
Addresses #195  

Updated colors for marker clusterer (based on the original color):

Small:  ![small](https://cloud.githubusercontent.com/assets/3673374/7966046/70d21d42-09ef-11e5-852d-96eeaa74a2d7.png)

Medium: ![medium](https://cloud.githubusercontent.com/assets/3673374/7966048/766eb83c-09ef-11e5-9191-e584aa7f0eea.png)

Large: ![large](https://cloud.githubusercontent.com/assets/3673374/7966054/7d0861a2-09ef-11e5-9520-58d087d5a400.png)
