### PR TITLE
added {{site.baseurl}}/ to favicon href

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,5 +25,5 @@
   {% for stylesheet in page.css %}
   <link rel="stylesheet" href="{{site.baseurl}}/css/{{ stylesheet }}">
   {% endfor %}
-  <link rel='shortcut icon' href='img/favicon.png' type='image/x-icon' />
+  <link rel='shortcut icon' href='{{site.baseurl}}/img/favicon.png' type='image/x-icon' />
 </head>


### PR DESCRIPTION
I noticed that the favicon was only showing up on the home page.

Home page (with favicon):
![home](https://cloud.githubusercontent.com/assets/1992577/7988760/2191f0e4-0ab3-11e5-807d-225bed92f381.png)

About page (without favicon):
![about](https://cloud.githubusercontent.com/assets/1992577/7988772/2b53975e-0ab3-11e5-8cf2-6903a697e0dd.png)

In head.html I added
```
 {{site.baseurl}}/
```
to the favicon href to fix the issue.

The favicon now appears on all pages!

About page (with favicon):
![about-fixed](https://cloud.githubusercontent.com/assets/1992577/7988849/916440c0-0ab3-11e5-97e5-905829977ce0.png)
