### PR TITLE
Conditional twitter rendering

### DIFF
--- a/chapters/index.html
+++ b/chapters/index.html
@@ -27,9 +27,11 @@ js:
  				{{else}}
  				{{ properties.title }}
  				{{/if}}
+ 				{{#if properties.twitter}}
  				<a href="http://twitter.com/{{ properties.twitter }}">
  					<img src="/img/twitter-icon.png"/>
  				</a>
+ 				{{/if}}
  				{{#if properties.facebook}}
  				<a href="{{ properties.facebook }}">
  					<img src="/img/facebook-icon.png" />

--- a/chapters/index.html
+++ b/chapters/index.html
@@ -56,7 +56,11 @@ js:
 	 			<p><strong>Organizers:</strong></p>
 	 			<ul>
 	 			{{#each properties.organizers}}
-	 				<li>{{name}} (<a href="http://twitter.com/{{twitter}}">@{{twitter}}</a>)</li>
+	 				{{#if twitter}}
+	 					<li>{{name}} (<a href="http://twitter.com/{{twitter}}">@{{twitter}}</a>)</li>
+	 				{{else}}
+	 					<li>{{name}}</li>
+	 				{{/if}}
 	 			{{/each}}
 	 			</ul>
  			{{/if}}


### PR DESCRIPTION
Currently, [maptime.io/chapters](http://maptime.io/chapters) renders twitter icons for all chapters and `(@)` for all organizers regardless of whether or not this data is present in [chapters.json](https://github.com/maptime/maptime.github.io/blob/master/_data/chapters.json?short_path=b2deb06).  Both link directly to twitter.com. This PR fixes that behavior.

### Before:

![lagos-before](https://cloud.githubusercontent.com/assets/1833870/8357846/0490adb8-1b2b-11e5-862a-10893c6c6f3f.png)

### After:

![lagos-after](https://cloud.githubusercontent.com/assets/1833870/8357859/1a00339e-1b2b-11e5-948e-109850bf74ee.png)
