### PR TITLE
Update chapter popup

### DIFF
--- a/js/chapters.js
+++ b/js/chapters.js
@@ -32,9 +32,15 @@ $(function() {
 
     var chapterMarkers = L.geoJson( data, {
       onEachFeature: function (feature, layer) {
-	    var popupOptions = {'maxWidth' : '1000'};  
-        var popupContent = '<h2>'+ feature.properties.title +'</h2>' + 'Twitter: ' + 
-          '<a href="http://twitter.com/' + feature.properties.twitter + '" target="_blank">@' + feature.properties.twitter +'</a>';
+        var popupOptions = {'maxWidth' : '1000'};  
+        var popupContent = '<h2>'+ feature.properties.title +'</h2>';
+        if (feature.properties.location && feature.properties.location.length  > 0) {
+          popupContent = popupContent + '<h3>'+ feature.properties.location +'</h3>';
+        }
+        if (feature.properties.twitter && feature.properties.twitter.length  > 0) {
+          popupContent = popupContent + 'Twitter: ' + '<a href="http://twitter.com/' + 
+            feature.properties.twitter + '" target="_blank">@' + feature.properties.twitter +'</a>';
+        }
         layer.bindPopup(popupContent,popupOptions);
         layer.setIcon(new L.Icon({
           iconUrl:'/img/maptime-marker.png',


### PR DESCRIPTION
Similar to #202, this removes twitter from the chapter map popup if none exists in chapters.json.

Also thought it might be nice to render the location in the popup since it's not always clear from the name of the chapter or its location on the basemap we're using.  Might be a more elegant JS way to do this but it works.  We might also want to add the location to the list as well.

Wanna have a look @geografa?

![chapter_location](https://cloud.githubusercontent.com/assets/1833870/8359085/402da248-1b32-11e5-9a27-1d06c4683e8f.png)
