### PR TITLE
render city name in list

### DIFF
--- a/chapters/index.html
+++ b/chapters/index.html
@@ -21,49 +21,52 @@ js:
 		<div class='chapter keyline-top'>
  			<h2>
  				{{#if properties.website}}
- 				<a href="{{properties.website}}">
- 					{{ properties.title }}
- 				</a>
+ 					<a href="{{properties.website}}">
+ 						{{ properties.title }}
+ 					</a>
  				{{else}}
- 				{{ properties.title }}
+ 					{{ properties.title }}
  				{{/if}}
- 				{{#if properties.twitter}}
- 				<a href="http://twitter.com/{{ properties.twitter }}">
- 					<img src="/img/twitter-icon.png"/>
- 				</a>
+ 					{{#if properties.twitter}}
+ 					<a href="http://twitter.com/{{ properties.twitter }}">
+ 						<img src="/img/twitter-icon.png"/>
+ 					</a>
  				{{/if}}
  				{{#if properties.facebook}}
- 				<a href="{{ properties.facebook }}">
- 					<img src="/img/facebook-icon.png" />
- 				</a>
+ 					<a href="{{ properties.facebook }}">
+ 						<img src="/img/facebook-icon.png" />
+ 					</a>
  				{{/if}}
  				{{#if properties.github}}
- 				<a href="{{ properties.github }}">
- 					<img src="/img/github-icon.png" />
- 				</a>
+ 					<a href="{{ properties.github }}">
+ 						<img src="/img/github-icon.png" />
+ 					</a>
  				{{/if}}
  				{{#if properties.meetup}}
- 				<a href="{{ properties.meetup }}">
- 					<img src="/img/meetup-icon.jpg" />
- 				</a>
+ 					<a href="{{ properties.meetup }}">
+ 						<img src="/img/meetup-icon.jpg" />
+ 					</a>
  				{{/if}}
  			</h2>
- 			{{#if properties.comingSoon}}
- 				<p>Coming Soon!</p>
- 			{{/if}}
+ 				{{#if properties.location}}
+ 					<p><strong>{{ properties.location }}</strong></p>
+ 				{{/if}}
+ 				{{#if properties.comingSoon}}
+ 					<p>Coming Soon!</p>
+ 				{{/if}}
  			
- 			{{#if properties.organizers}}
-	 			<p><strong>Organizers:</strong></p>
-	 			<ul>
-	 			{{#each properties.organizers}}
-	 				{{#if twitter}}
-	 					<li>{{name}} (<a href="http://twitter.com/{{twitter}}">@{{twitter}}</a>)</li>
-	 				{{else}}
-	 					<li>{{name}}</li>
-	 				{{/if}}
-	 			{{/each}}
-	 			</ul>
- 			{{/if}}
+ 				{{#if properties.organizers}}
+	 				<p><em>Organizers:</em></p>
+	 				<ul>
+	 					{{#each properties.organizers}}
+	 						{{#if twitter}}
+	 							<li>{{name}} (<a href="http://twitter.com/{{twitter}}">@{{twitter}}</a>)</li>
+	 						{{else}}
+	 							<li>{{name}}</li>
+	 						{{/if}}
+	 					{{/each}}
+	 				</ul>
+ 				{{/if}}
  		</div>​
  	{{/each}}
 ​</script>

--- a/css/site.css
+++ b/css/site.css
@@ -365,6 +365,9 @@ a.fill-darken0:hover  { background-color:rgba(0,0,0,0.15); }
 .chapter h2:first-child {
   padding-top: 20px;
 }
+.chapter h2 {
+  margin-bottom: 0px;
+}
 
 
 @media only screen and (max-width:800px) {


### PR DESCRIPTION
Rendered city name in the chapters list at [maptime.io/chapters ](http://maptime.io/chapters). This was the best I could do and still conform to HTML5 since I didn't feel like fooling around with css.  I think ultimately this page will undergo a redesign anyway.

Also did a bit of prettifying.

Look ok? @geografa @lyzidiamond 

![city-rendering](https://cloud.githubusercontent.com/assets/1833870/9547678/f998258c-4d69-11e5-90f0-93e3c0a85e48.png)


Fixes #209