### PR TITLE
add jekyll-feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 gem 'github-pages'
+gem 'jekyll-feed'
 gem 'html-proofer', github: 'gjtorikian/html-proofer', :tag => 'v2.4.2'
 gem 'geojsonlint'
 gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       toml (~> 0.1.0)
     jekyll-coffeescript (1.0.0)
       coffee-script (~> 2.2)
+    jekyll-feed (0.3.1)
     jekyll-gist (1.1.0)
     jekyll-mentions (0.1.3)
       html-pipeline (~> 1.9.0)
@@ -153,6 +154,7 @@ DEPENDENCIES
   github-pages
   html-proofer!
   httparty
+  jekyll-feed
 
 BUNDLED WITH
    1.10.6

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+url: http://maptime.io
 baseurl:
 permalink: pretty
 markdown: kramdown
@@ -11,3 +12,6 @@ maptime:
 
 excerpt_separator: <!--more-->
 exclude: [vendor]
+
+gems:
+  - jekyll-feed


### PR DESCRIPTION
Fixes #231 

Creates an atom feed at maptime.io/feed.xml

![2015-10-02-222735_1920x1054_scrot](https://cloud.githubusercontent.com/assets/1833870/10261098/44eb27d0-6955-11e5-8a5f-4d730eaa892f.png)
