### PR TITLE
Ignore failing external links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.2.2
 script:
   - bundle exec jekyll build
-  - bundle exec htmlproofer ./_site --only-4xx --check-html --empty-alt-ignore --url-ignore "#"
+  - bundle exec htmlproofer ./_site --disable_external --only-4xx --check-html --empty-alt-ignore --url-ignore "#"
   - result=$(geojsonhint --json < _data/chapters.json); echo "$result"; ! grep -qF '"error":' <<< "$result"
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.2.2
 script:
   - bundle exec jekyll build
-  - bundle exec htmlproofer ./_site --disable_external --only-4xx --check-html --empty-alt-ignore --url-ignore "#"
+  - bundle exec htmlproofer ./_site --disable-external --only-4xx --check-html --empty-alt-ignore --url-ignore "#"
   - result=$(geojsonhint --json < _data/chapters.json); echo "$result"; ! grep -qF '"error":' <<< "$result"
 env:
   global:


### PR DESCRIPTION
It appears that all builds are failing. This is because some blogposts reference no-longer-available external resources.  I feel that it's best to keep blog posts as they were when they were written.  Instead, I recommend we ignore checking the status of external links.