### PR TITLE
fix link FR: anatomie-d-une-webmap

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -163,7 +163,7 @@
   tags:
     - Web mapping
   description: a french translation of Anatomy of a Web Map
-  link: http://maptime-alpes.com/anatomie-d-une-webmap/
+  link: https://maptimealpes.github.io/anatomie-d-une-webmap/
 
 - name: Introduction to Geographic Data Formats
   tags:


### PR DESCRIPTION
Fixing #308 by updating the link to the french translation of Anatomy of a WebMap
 